### PR TITLE
Add centos7 based optional midonet containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ Usage
     $ docker run -ti --link midonetdockerfile_api_1:api midonet/midonet-cli midonet-cli
 ```
 
+* If you want to try out the centos version of the midonet containers you can
+  just modify the fig.yml file to point to the docker images for midolman,
+  midonet-api and midonet-cli with tag 2014.11-rc3_centos (or newer '\_centos'
+  tag). Then run:
+
+```bash
+    $ docker run -ti --link midonetdockerfile_api_1:api midonet/midonet-cli:2014.11-rc3_centos midonet-cli
+```
+
 
 Alternative installation
 ------------------------

--- a/build_testing_images.sh
+++ b/build_testing_images.sh
@@ -7,11 +7,14 @@ docker build -t midonet/zookeeper dockerfiles/misc/zookeeper
 docker build -t midonet/cassandra:2.1.2 dockerfiles/misc/cassandra
 docker build -t midonet/cassandra dockerfiles/misc/cassandra
 
+docker build -t midonet/midolman:2014.11-rc3_centos dockerfiles/centos/midolman
 docker build -t midonet/midolman:2014.11-rc3_ubuntu dockerfiles/ubuntu/midolman
 docker build -t midonet/midolman dockerfiles/ubuntu/midolman
 
+docker build -t midonet/midonet-api:2014.11-rc3_centos dockerfiles/centos/midonet-api
 docker build -t midonet/midonet-api:2014.11-rc3_ubuntu dockerfiles/ubuntu/midonet-api
 docker build -t midonet/midonet-api dockerfiles/ubuntu/midonet-api
 
+docker build -t midonet/midonet-cli:2014.11-rc3_centos dockerfiles/centos/midonet-cli
 docker build -t midonet/midonet-cli:2014.11-rc3_ubuntu dockerfiles/ubuntu/midonet-cli
 docker build -t midonet/midonet-cli dockerfiles/ubuntu/midonet-cli

--- a/dockerfiles/centos/midolman/Dockerfile
+++ b/dockerfiles/centos/midolman/Dockerfile
@@ -1,0 +1,16 @@
+# Dockerfile to build midolman rc version for centos
+FROM centos:centos7
+MAINTAINER Antoni Segura Puimedon "toni@midokura.com"
+
+# Add the yum repo configuration file
+ADD conf/midonet.repo /etc/yum.repos.d/midonet.repo
+
+# Update repository
+RUN yum update -y
+RUN yum install -y midolman
+
+# Add init script
+ADD run_midolman.sh /opt/run_midolman.sh
+
+# Run midolman by default
+CMD /opt/run_midolman.sh

--- a/dockerfiles/centos/midolman/conf/midonet.repo
+++ b/dockerfiles/centos/midolman/conf/midonet.repo
@@ -1,0 +1,7 @@
+[midonet] 
+name=MidoNet
+baseurl=http://repo.midonet.org/midonet/v2014.11/RHEL/7/testing/
+enabled=1
+gpgcheck=1
+gpgkey=http://repo.midonet.org/RPM-GPG-KEY-midokura
+

--- a/dockerfiles/centos/midolman/run_midolman.sh
+++ b/dockerfiles/centos/midolman/run_midolman.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sed -i '/^servers/c\servers = '$CS_PORT_9042_TCP_ADDR:$CS_PORT_9042_TCP_PORT'' /etc/midolman/midolman.conf
+sed -i '/^zookeeper_hosts/c\zookeeper_hosts = '$ZK_PORT_2181_TCP_ADDR:$ZK_PORT_2181_TCP_PORT'' /etc/midolman/midolman.conf 
+
+exec /usr/share/midolman/midolman-start

--- a/dockerfiles/centos/midonet-api/Dockerfile
+++ b/dockerfiles/centos/midonet-api/Dockerfile
@@ -1,0 +1,20 @@
+# Dockerfile to build midolman-api rc version for centos7
+FROM centos:centos7
+MAINTAINER Antoni Segura Puimedon "toni@midokura.com"
+
+# Expose port for other processes
+EXPOSE 8080
+
+# Add the yum repo configuration file
+ADD conf/midonet.repo /etc/yum.repos.d/midonet.repo
+
+# Install dependences
+RUN yum update -y
+RUN yum install -y tomcat midonet-api
+
+# Configure midonet-api
+ADD conf/midonet-api.xml /etc/tomcat/Catalina/localhost/midonet-api.xml
+ADD bin/run_midonetapi.sh /opt/run_midonetapi.sh
+
+# Run midonet-api script by default
+CMD /opt/run_midonetapi.sh

--- a/dockerfiles/centos/midonet-api/bin/run_midonetapi.sh
+++ b/dockerfiles/centos/midonet-api/bin/run_midonetapi.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Edit web.xml
+
+MIDONET_API_CFG=/usr/share/midonet-api/WEB-INF/web.xml
+IP=$(ip -4 a show dev eth0 | grep inet | awk '{print $2;}' | cut -d'/' -f1)
+
+sed -i -e "/<param-name>rest_api-base_uri<\/param-name>/{n;s%.*%    <param-value>http://"$IP":8080/midonet-api</param-value>%g}" $MIDONET_API_CFG
+sed -i -e "/<param-name>zookeeper-zookeeper_hosts<\/param-name>/{n;n;s%.*%    <param-value>"$ZK_PORT_2181_TCP_ADDR:$ZK_PORT_2181_TCP_PORT"</param-value>%g}" $MIDONET_API_CFG
+sed -i -e "s/org.midonet.api.auth.keystone.v2_0.KeystoneService/org.midonet.api.auth.MockAuthService/g" $MIDONET_API_CFG
+
+# Run tomcat
+exec java -classpath /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat -Djava.endorsed.dirs= -Djava.io.tmpdir=/var/cache/tomcat/temp -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager org.apache.catalina.startup.Bootstrap start

--- a/dockerfiles/centos/midonet-api/conf/midonet-api.xml
+++ b/dockerfiles/centos/midonet-api/conf/midonet-api.xml
@@ -1,0 +1,6 @@
+<Context
+    path="/midonet-api"
+    docBase="/usr/share/midonet-api"
+    antiResourceLocking="false"
+    privileged="true"
+/>

--- a/dockerfiles/centos/midonet-api/conf/midonet.repo
+++ b/dockerfiles/centos/midonet-api/conf/midonet.repo
@@ -1,0 +1,6 @@
+[midonet] 
+name=MidoNet
+baseurl=http://repo.midonet.org/midonet/v2014.11/RHEL/7/unstable/
+enabled=1
+gpgcheck=1
+gpgkey=http://repo.midonet.org/RPM-GPG-KEY-midokura

--- a/dockerfiles/centos/midonet-cli/Dockerfile
+++ b/dockerfiles/centos/midonet-cli/Dockerfile
@@ -1,0 +1,18 @@
+# Dockerfile to build midolman-api rc version for centos7
+FROM centos:centos7
+MAINTAINER Antoni Segura Puimedon "toni@midokura.com"
+
+# Expose port for other processes
+EXPOSE 8080
+
+# Add the yum repo configuration file
+ADD conf/midonet.repo /etc/yum.repos.d/midonet.repo
+# Add the EPEL yum repo for the python-midonetclient dependencies
+RUN yum install -y http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+
+# Install dependences
+RUN yum update -y
+RUN yum install -y python-midonetclient
+
+# Configure midonet-api
+ADD conf/midonetrc /root/.midonetrc

--- a/dockerfiles/centos/midonet-cli/conf/midonet.repo
+++ b/dockerfiles/centos/midonet-cli/conf/midonet.repo
@@ -1,0 +1,6 @@
+[midonet] 
+name=MidoNet
+baseurl=http://repo.midonet.org/midonet/v2014.11/RHEL/7/unstable/
+enabled=1
+gpgcheck=1
+gpgkey=http://repo.midonet.org/RPM-GPG-KEY-midokura

--- a/dockerfiles/centos/midonet-cli/conf/midonetrc
+++ b/dockerfiles/centos/midonet-cli/conf/midonetrc
@@ -1,0 +1,5 @@
+[cli]
+api_url = http://api:8080/midonet-api
+username = admin
+password = admin
+project_id = admin


### PR DESCRIPTION
This patch adds building centos7 images for the midonet specific
containers and makes it possible to run them alongside the
ubuntu based cassandra and zookeeper ones.

To try it out:

echo >> fig.yml <<EOF
zookeeper:
  image: midonet/zookeeper
cassandra:
  image: midonet/cassandra
midolman:
  image: midonet/midolman:2014.11-rc3_centos
  links:
- "zookeeper:zk"
- "cassandra:cs"
  privileged: true
  api:
  image: midonet/midonet-api:2014.11-rc3_centos
  links:
- "zookeeper:zk"
  ports:
- "8080:8080"
  EOF

$ docker run -ti --link midonetdockerfile_api_1:api midonet/midonet-cli:2014.11-rc3_centos midonet-cli
